### PR TITLE
ceccommon.h: Fix compile under linux

### DIFF
--- a/ceccommon.h
+++ b/ceccommon.h
@@ -24,27 +24,27 @@
 #include <stdbool.h>
 #include <math.h>
 #include <stdio.h>
-#include "driver\bk4819.h"
-#include "driver\keyboard.h"
+#include "driver/bk4819.h"
+#include "driver/keyboard.h"
 #include "audio.h"
 #include "string.h"
 #include <stdint.h>
 #include <string.h>
 #include "external/printf/printf.h"
 //#include "gpsinfo.h"
-#include "driver\eeprom.h"
+#include "driver/eeprom.h"
 #include "misc.h"
 #include "radio.h"
-#include "driver\system.h"
-#include "driver\st7565.h"
+#include "driver/system.h"
+#include "driver/st7565.h"
 #include "settings.h"
-#include "driver\systick.h"
-#include "ui\helper.h"
-#include "ui\ui.h"
-#include "ui\main.h"
+#include "driver/systick.h"
+#include "ui/helper.h"
+#include "ui/ui.h"
+#include "ui/main.h"
 #include "font.h"
 #include "functions.h"
-#include "app\app.h"
+#include "app/app.h"
 
 #define _MAX_READ_CH_ATTRIBUTES 7
 #define COMBUFF_USE_SEEK_RSSI   01


### PR DESCRIPTION
At unix systems, the repo won't compile, as paths are written with `/` instead of `\`. Changing the paths to unix convention enables us to compile it there too.

As the other files use that convention already and you produced binary packages, it shouldn't result in problems on windows systems.

Fixes #17 